### PR TITLE
Set default value for "sublime_packages: version:" to master

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,7 @@
     dest: "~/Library/Application Support/Sublime Text 3/Installed Packages/Package Control.sublime-package"
 
 - name: get and update all sublime plugins
-  git: update=yes version="{{item.version}}" repo="{{item.repo}}" dest="~/Library/Application Support/Sublime Text 3/Packages/{{item.dest}}"
+  git: update=yes version="{{item.version|default('master')}}" repo="{{item.repo}}" dest="~/Library/Application Support/Sublime Text 3/Packages/{{item.dest}}"
   with_items: "{{ sublime_packages }}"
 
 - name: render the sublime config file


### PR DESCRIPTION
 Now it is possible to omit version if it is ''master':

   - sublime_packages:
        - dest: "GitGutter"
          repo: "https://github.com/jisaacks/GitGutter.git"
        - dest: "SideBarEnhancements"
          repo: "https://github.com/titoBouzout/SideBarEnhancements"
          version: "st3"